### PR TITLE
Change shebang lines from /bin/sh to /bin/bash

### DIFF
--- a/enforce-dpms.sh
+++ b/enforce-dpms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ueo pipefail
 
 DRM_DEVICE_PATH=/sys/class/graphics/fb0/device/drm/card0

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ueo pipefail
 
 DIRNAME=$(dirname $0)

--- a/screen-log.sh
+++ b/screen-log.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ueo pipefail
 
 LOGFILE=${HOME}/screen-log-$(date +%Y%m%d-%H%M%S).csv


### PR DESCRIPTION
The shell scripts use several constructs not available in a standard shell, causing them to fail if run with a shell that does not support them (such as `dash`). Among these are `set -o pipefail`, the `function` keyword, or ranges like `{1..150}`. Specifying `bash` ensures that the selected shell supports all features currently used in the scripts.