### PR TITLE
Include all possible DRM device paths

### DIFF
--- a/enforce-dpms.sh
+++ b/enforce-dpms.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 set -ueo pipefail
 
-DRM_DEVICE_PATH=/sys/class/graphics/fb0/device/drm/card0
+DRM_DEVICE_PATH=/sys/class/graphics/fb*/device/drm/card*
 ALL_DRM_PORTS=$(find ${DRM_DEVICE_PATH} | grep '/dpms$')
 DEBUG=0
 


### PR DESCRIPTION
Currently, `DRM_DEVICE_PATH=/sys/class/graphics/fb0/device/drm/card0` is hard-coded. However, on some systems, this specific path may not exist (for example, I have `/sys/class/graphics/fb0/device/drm/card1` and `/sys/class/graphics/fb1/device/drm/card0`), causing the entire script to fail. To prevent this, replace the hard-coded “0”s by globs.